### PR TITLE
Update links for React Navigation's documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,13 @@ We have an active channel on the [Reactiflux](https://www.reactiflux.com/) commu
 
 ## Advanced guide
 
-- [Redux integration](https://reactnavigation.org/docs/guides/redux)
+- [Redux integration](https://reactnavigation.org/docs/redux-integration.html)
 - [Web integration](https://reactnavigation.org/docs/guides/web)
-- [Deep linking](https://reactnavigation.org/docs/guides/linking)
-- [Contributors guide](https://reactnavigation.org/docs/guides/contributors)
+- [Deep linking](https://reactnavigation.org/docs/deep-linking.html)
+- [Contributors guide](https://reactnavigation.org/docs/contributing.html)
 
 ## React Navigation API
 
-- [Navigators](https://reactnavigation.org/docs/navigators/)
-- [Routers](https://reactnavigation.org/docs/routers/)
-- [Views](https://reactnavigation.org/docs/views/)
-
+- [Navigators](https://reactnavigation.org/docs/custom-navigator-overview.html)
+- [Routers](https://reactnavigation.org/docs/routers.html)
+- [Views](https://reactnavigation.org/docs/navigation-views.html)


### PR DESCRIPTION
In README.md file, links for React Navigation documents are inaccessible. Documentation structure might have changed so the links are not pointing to proper urls. It is giving **'404 File not found'** error.

**Fix:**
I have updated the urls in README.md file. They are pointing to correct URL now. 
(I couldn't find a document for 'Web integration' in React Navigation. For now, I have kept it as it is.)

**Testing:**
Links are pointing to proper documentation sections.

